### PR TITLE
Fix always listening on port 7357

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,6 +110,10 @@ func main() {
 	}
 
 	events.Add(events.OnStart())
-	info.Printf("listening on port:%v\n", *port)
-	info.Println(http.ListenAndServe(fmt.Sprintf(":%v", *port), httpApi))
+	if *port != 0 {
+		info.Printf("listening on port:%v\n", *port)
+		info.Println(http.ListenAndServe(fmt.Sprintf(":%v", *port), httpApi))
+	} else {
+		info.Printf("listening port disabled\n")
+	}
 }


### PR DESCRIPTION
Running multiple custom-runner containers side-by-side results in an error, because by default it is always listening on port 7357.

This PR allows one to disable it by running it with `--port=0`.