### PR TITLE
refactor: change go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kube-logging/custom-runner
 
-go 1.24.4
+go 1.24.3
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module example.com/gocr
+module github.com/kube-logging/custom-runner
 
-go 1.23.5
+go 1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0
@@ -8,4 +8,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.29.0 // indirect
+require golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"strings"
 
-	"example.com/gocr/src/api"
-	"example.com/gocr/src/config"
-	"example.com/gocr/src/events"
-	"example.com/gocr/src/filewatcher"
-	"example.com/gocr/src/httpapi"
-	"example.com/gocr/src/info"
-	"example.com/gocr/src/process"
+	"github.com/kube-logging/custom-runner/src/api"
+	"github.com/kube-logging/custom-runner/src/config"
+	"github.com/kube-logging/custom-runner/src/events"
+	"github.com/kube-logging/custom-runner/src/filewatcher"
+	"github.com/kube-logging/custom-runner/src/httpapi"
+	"github.com/kube-logging/custom-runner/src/info"
+	"github.com/kube-logging/custom-runner/src/process"
 )
 
 type ExecArgs struct {

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "configMigration": true,
   "constraints": {
-    "go": "1.23"
+    "go": "1.24"
   },
   "customManagers": [
     {

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -4,9 +4,9 @@ package api
 import (
 	"fmt"
 
-	"example.com/gocr/src/api/types"
-	"example.com/gocr/src/config"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	"github.com/kube-logging/custom-runner/src/config"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 type API struct {

--- a/src/api/config.go
+++ b/src/api/config.go
@@ -2,8 +2,8 @@
 package api
 
 import (
-	"example.com/gocr/src/api/types"
-	"example.com/gocr/src/config"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	"github.com/kube-logging/custom-runner/src/config"
 )
 
 func (a *API) Config() types.ApiResult {

--- a/src/api/exec.go
+++ b/src/api/exec.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"os/exec"
 
-	"example.com/gocr/src/api/types"
-	"example.com/gocr/src/events"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	"github.com/kube-logging/custom-runner/src/events"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 func (a *API) Exec(key ptypes.Key, command string) types.ApiResult {

--- a/src/api/exit.go
+++ b/src/api/exit.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"example.com/gocr/src/api/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
 )
 
 func (a *API) Exit() types.ApiResult {

--- a/src/api/get.go
+++ b/src/api/get.go
@@ -4,8 +4,8 @@ package api
 import (
 	"fmt"
 
-	"example.com/gocr/src/api/types"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 func (a *API) Get(key ptypes.Key) types.ApiResult {

--- a/src/api/kill.go
+++ b/src/api/kill.go
@@ -4,8 +4,8 @@ package api
 import (
 	"fmt"
 
-	"example.com/gocr/src/api/types"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 func (a *API) Kill(key ptypes.Key) types.ApiResult {

--- a/src/api/list.go
+++ b/src/api/list.go
@@ -2,8 +2,8 @@
 package api
 
 import (
-	"example.com/gocr/src/api/types"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 func (a *API) List() types.ApiResult {

--- a/src/api/restart.go
+++ b/src/api/restart.go
@@ -4,8 +4,8 @@ package api
 import (
 	"fmt"
 
-	"example.com/gocr/src/api/types"
-	ptypes "example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/api/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 func (a *API) Restart(key ptypes.Key) types.ApiResult {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"example.com/gocr/src/events"
+	"github.com/kube-logging/custom-runner/src/events"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v3"
 )

--- a/src/events/apievent.go
+++ b/src/events/apievent.go
@@ -2,7 +2,7 @@
 package events
 
 import (
-	ptypes "example.com/gocr/src/process/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 type ApiEvent struct {

--- a/src/events/types.go
+++ b/src/events/types.go
@@ -2,7 +2,7 @@
 package events
 
 import (
-	ptypes "example.com/gocr/src/process/types"
+	ptypes "github.com/kube-logging/custom-runner/src/process/types"
 )
 
 type ITEvent interface {

--- a/src/filewatcher/types.go
+++ b/src/filewatcher/types.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"path/filepath"
 
-	"example.com/gocr/src/events"
 	"github.com/fsnotify/fsnotify"
+	"github.com/kube-logging/custom-runner/src/events"
 )
 
 type FileWatcher struct {

--- a/src/httpapi/httpapi.go
+++ b/src/httpapi/httpapi.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"regexp"
 
-	"example.com/gocr/src/api"
-	"example.com/gocr/src/api/types"
+	"github.com/kube-logging/custom-runner/src/api"
+	"github.com/kube-logging/custom-runner/src/api/types"
 )
 
 const (

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -4,7 +4,7 @@ package process
 import (
 	"sync"
 
-	"example.com/gocr/src/process/types"
+	"github.com/kube-logging/custom-runner/src/process/types"
 )
 
 type Process struct {


### PR DESCRIPTION
the previous modul path was `example.com/gocr` changed it to the github path: `github.com/kube-logging/custom-runner`

Fixes: https://github.com/kube-logging/logging-operator/issues/2054