### PR TITLE
fix: pin cosign installer version to 3.10.0

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
         if: ${{ inputs.publish }}
 
       - name: Set image name

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,15 @@
         "Add build label to PRs which are related to build tools defined in Makefiles.",
         "Group Makefile dependency updates in single PR."
       ]
+    },
+    {
+      "matchDepNames": [
+        "sigstore/cosign-installer"
+      ],
+      "allowedVersions": "3.10.0",
+      "description": [
+        "Pin sigstore/cosign-installer to v3.10.0 (d7543c93d881b35a8faa02e8e3605f69b7a1ce62)."
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Version >4.0.0 contains great amount of breaking-changes, that we cannot support at the moment.